### PR TITLE
Bmp180 sensor

### DIFF
--- a/robophery/i2c/__init__.py
+++ b/robophery/i2c/__init__.py
@@ -1,5 +1,5 @@
 
-import smbus
+#import smbus
 from robophery.core import Module
 
 #Type of I2C interface to manage system device
@@ -8,12 +8,20 @@ I2C_ADAFRUIT_I2C_INTERFACE = 2
 
 class I2cModule(Module):
 
-    def set_bus(self, bus):
+    def set_bus(self, bus, address, interface=I2C_SMBUS_INTERFACE):
         """
         Set bus for reading.
         """
-        self.bus = smbus.SMBus(int(bus))
+        #self.bus = smbus.SMBus(int(bus))
 
+        # Create I2C device.
+        if interface is I2C_ADAFRUIT_I2C_INTERFACE:
+            import Adafruit_GPIO.I2C as I2C
+            #i2c = I2C
+            self.bus = I2C.get_i2c_device(address, bus)
+        elif (self._i2c_interface is I2C_SMBUS_INTERFACE):
+            import smbus
+            self.bus = smbus.SMBus(bus)
 
     def set_addr(self, addr):
         """

--- a/robophery/i2c/__init__.py
+++ b/robophery/i2c/__init__.py
@@ -8,18 +8,27 @@ I2C_ADAFRUIT_I2C_INTERFACE = 2
 
 class I2cModule(Module):
 
-    def set_bus(self, bus, address, interface=I2C_SMBUS_INTERFACE):
+    #def set_device(self, address, bus, interface=I2C_SMBUS_INTERFACE):
+    #    """
+    #    Set up I2C device.
+    #    """
+    #    # Create I2C device.
+    #    if interface is I2C_ADAFRUIT_I2C_INTERFACE:
+    #        import Adafruit_GPIO.I2C as I2C
+    #        #i2c = I2C
+    #        self.bus = I2C.get_i2c_device(address, bus)
+    #    elif (interface is I2C_SMBUS_INTERFACE):
+    #        import smbus
+    #        self.bus = smbus.SMBus(bus)
+
+    def set_bus(self, bus, interface=I2C_SMBUS_INTERFACE):
         """
         Set bus for reading.
         """
-        #self.bus = smbus.SMBus(int(bus))
-
-        # Create I2C device.
         if interface is I2C_ADAFRUIT_I2C_INTERFACE:
-            import Adafruit_GPIO.I2C as I2C
-            #i2c = I2C
-            self.bus = I2C.get_i2c_device(address, bus)
-        elif (self._i2c_interface is I2C_SMBUS_INTERFACE):
+            #Adafruit interface has bus implemented in different object
+            self.bus = 0;
+        elif (interface is I2C_SMBUS_INTERFACE):
             import smbus
             self.bus = smbus.SMBus(bus)
 

--- a/robophery/i2c/__init__.py
+++ b/robophery/i2c/__init__.py
@@ -1,5 +1,5 @@
 
-#import smbus
+import smbus
 from robophery.core import Module
 
 #Type of I2C interface to manage system device

--- a/robophery/i2c/__init__.py
+++ b/robophery/i2c/__init__.py
@@ -1,9 +1,12 @@
 
-import smbus
+#import smbus
 from robophery.core import Module
 
-class I2cModule(Module):
+#Type of I2C interface to manage system device
+I2C_SMBUS_INTERFACE = 1
+I2C_ADAFRUIT_I2C_INTERFACE = 2
 
+class I2cModule(Module):
 
     def set_bus(self, bus):
         """

--- a/robophery/i2c/__init__.py
+++ b/robophery/i2c/__init__.py
@@ -3,34 +3,25 @@
 from robophery.core import Module
 
 #Type of I2C interface to manage system device
-I2C_SMBUS_INTERFACE = 1
-I2C_ADAFRUIT_I2C_INTERFACE = 2
+#I2C_SMBUS_INTERFACE = 1
+#I2C_ADAFRUIT_I2C_INTERFACE = 2
 
 class I2cModule(Module):
 
-    #def set_device(self, address, bus, interface=I2C_SMBUS_INTERFACE):
-    #    """
-    #    Set up I2C device.
-    #    """
-    #    # Create I2C device.
-    #    if interface is I2C_ADAFRUIT_I2C_INTERFACE:
-    #        import Adafruit_GPIO.I2C as I2C
-    #        #i2c = I2C
-    #        self.bus = I2C.get_i2c_device(address, bus)
-    #    elif (interface is I2C_SMBUS_INTERFACE):
-    #        import smbus
-    #        self.bus = smbus.SMBus(bus)
+    def set_device(self, address, busnum):
+        """
+        Set up I2C device for drivers using Adafruit_GPIO.I2C.
+        """
+        import Adafruit_GPIO.I2C as I2C
+        #i2c = I2C
+        self._device = I2C.get_i2c_device(address, busnum)
 
-    def set_bus(self, bus, interface=I2C_SMBUS_INTERFACE):
+    def set_bus(self, busnum):
         """
-        Set bus for reading.
+        Set up bus for drivers using SMBus directly. 
         """
-        if interface is I2C_ADAFRUIT_I2C_INTERFACE:
-            #Adafruit interface has bus implemented in different object
-            self.bus = 0;
-        elif (interface is I2C_SMBUS_INTERFACE):
-            import smbus
-            self.bus = smbus.SMBus(bus)
+        import smbus
+        self.bus = smbus.SMBus(busnum)
 
     def set_addr(self, addr):
         """

--- a/robophery/i2c/bmp085.py
+++ b/robophery/i2c/bmp085.py
@@ -23,7 +23,7 @@
 from __future__ import division
 import logging
 import time
-from robophery.i2c import (I2cModule, I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
+from robophery.i2c import I2cModule
 
 BMP085_NAME_DEFAULT      = 'BMP085 sensor'
 # BMP085 default address.
@@ -67,9 +67,8 @@ class BMP085Module(I2cModule):
         self._mode = kwargs.get('mode')
         #TODO make this as kwarg
         self.set_addr(kwargs.get('address'))
-        self.set_bus(kwargs.get('bus'), I2C_ADAFRUIT_I2C_INTERFACE)
 
-        self._device = i2c.get_i2c_device(self.addr, **kwargs)
+        self.set_device(kwargs.get('address'), kwargs.get('busnum'))
 
         self._logger = logging.getLogger('Adafruit_BMP.BMP085')
 

--- a/robophery/i2c/bmp085.py
+++ b/robophery/i2c/bmp085.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+#TODO Is this neccessary?
+from __future__ import division
+import logging
+import time
+from robophery.i2c import I2cModule
+
+# BMP085 default address.
+BMP085_I2CADDR           = 0x77
+
+# Operating Modes
+BMP085_ULTRALOWPOWER     = 0
+BMP085_STANDARD          = 1
+BMP085_HIGHRES           = 2
+BMP085_ULTRAHIGHRES      = 3
+
+# BMP085 Registers
+BMP085_CAL_AC1           = 0xAA  # R   Calibration data (16 bits)
+BMP085_CAL_AC2           = 0xAC  # R   Calibration data (16 bits)
+BMP085_CAL_AC3           = 0xAE  # R   Calibration data (16 bits)
+BMP085_CAL_AC4           = 0xB0  # R   Calibration data (16 bits)
+BMP085_CAL_AC5           = 0xB2  # R   Calibration data (16 bits)
+BMP085_CAL_AC6           = 0xB4  # R   Calibration data (16 bits)
+BMP085_CAL_B1            = 0xB6  # R   Calibration data (16 bits)
+BMP085_CAL_B2            = 0xB8  # R   Calibration data (16 bits)
+BMP085_CAL_MB            = 0xBA  # R   Calibration data (16 bits)
+BMP085_CAL_MC            = 0xBC  # R   Calibration data (16 bits)
+BMP085_CAL_MD            = 0xBE  # R   Calibration data (16 bits)
+BMP085_CONTROL           = 0xF4
+BMP085_TEMPDATA          = 0xF6
+BMP085_PRESSUREDATA      = 0xF6
+
+# Commands
+BMP085_READTEMPCMD       = 0x2E
+BMP085_READPRESSURECMD   = 0x34
+
+class BMP085Module(I2cModule):
+
+    def __init__(self, kwargs):
+        self.name = kwargs.get('name')
+        if kwargs.get('mode') not in [BMP085_ULTRALOWPOWER, BMP085_STANDARD, BMP085_HIGHRES, BMP085_ULTRAHIGHRES]:
+            raise ValueError('Unexpected mode value {0}.  Set mode to one of BMP085_ULTRALOWPOWER, BMP085_STANDARD, BMP085_HIGHRES, or BMP085_ULTRAHIGHRES'.format(mode))
+        self._mode = kwargs.get('mode')
+        if kwargs.get('i2c_interface') not in [I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE]:
+            raise ValueError('Unexpected i2c_interface value {0}.  Set I2C interface to one of I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE'.format(mode))
+        self._i2c_interface = kwargs.get('i2c_interface')
+
+#TODO This logic should be in init. Left for initil testing as it is.
+        # Create I2C device.
+        if self._i2c_interface is I2C_ADAFRUIT_I2C_INTERFACE:
+            import Adafruit_GPIO.I2C as I2C
+            i2c = I2C
+            self._device = i2c.get_i2c_device(address, **kwargs)
+        elif (self._i2c_interface is I2C_SMBUS_INTERFACE):
+            self.set_bus(kwargs.get('bus'))
+
+        self._logger = logging.getLogger('Adafruit_BMP.BMP085')
+
+        # Load calibration values.
+        self._load_calibration()
+
+    def _load_calibration(self):
+        self.cal_AC1 = self._device.readS16BE(BMP085_CAL_AC1)   # INT16
+        self.cal_AC2 = self._device.readS16BE(BMP085_CAL_AC2)   # INT16
+        self.cal_AC3 = self._device.readS16BE(BMP085_CAL_AC3)   # INT16
+        self.cal_AC4 = self._device.readU16BE(BMP085_CAL_AC4)   # UINT16
+        self.cal_AC5 = self._device.readU16BE(BMP085_CAL_AC5)   # UINT16
+        self.cal_AC6 = self._device.readU16BE(BMP085_CAL_AC6)   # UINT16
+        self.cal_B1 = self._device.readS16BE(BMP085_CAL_B1)     # INT16
+        self.cal_B2 = self._device.readS16BE(BMP085_CAL_B2)     # INT16
+        self.cal_MB = self._device.readS16BE(BMP085_CAL_MB)     # INT16
+        self.cal_MC = self._device.readS16BE(BMP085_CAL_MC)     # INT16
+        self.cal_MD = self._device.readS16BE(BMP085_CAL_MD)     # INT16
+        self._logger.debug('AC1 = {0:6d}'.format(self.cal_AC1))
+        self._logger.debug('AC2 = {0:6d}'.format(self.cal_AC2))
+        self._logger.debug('AC3 = {0:6d}'.format(self.cal_AC3))
+        self._logger.debug('AC4 = {0:6d}'.format(self.cal_AC4))
+        self._logger.debug('AC5 = {0:6d}'.format(self.cal_AC5))
+        self._logger.debug('AC6 = {0:6d}'.format(self.cal_AC6))
+        self._logger.debug('B1 = {0:6d}'.format(self.cal_B1))
+        self._logger.debug('B2 = {0:6d}'.format(self.cal_B2))
+        self._logger.debug('MB = {0:6d}'.format(self.cal_MB))
+        self._logger.debug('MC = {0:6d}'.format(self.cal_MC))
+        self._logger.debug('MD = {0:6d}'.format(self.cal_MD))
+
+    def _load_datasheet_calibration(self):
+        # Set calibration from values in the datasheet example.  Useful for debugging the
+        # temp and pressure calculation accuracy.
+        self.cal_AC1 = 408
+        self.cal_AC2 = -72
+        self.cal_AC3 = -14383
+        self.cal_AC4 = 32741
+        self.cal_AC5 = 32757
+        self.cal_AC6 = 23153
+        self.cal_B1 = 6190
+        self.cal_B2 = 4
+        self.cal_MB = -32767
+        self.cal_MC = -8711
+        self.cal_MD = 2868
+
+    def read_raw_temp(self):
+        """Reads the raw (uncompensated) temperature from the sensor."""
+        self._device.write8(BMP085_CONTROL, BMP085_READTEMPCMD)
+        time.sleep(0.005)  # Wait 5ms
+        raw = self._device.readU16BE(BMP085_TEMPDATA)
+        self._logger.debug('Raw temp 0x{0:X} ({1})'.format(raw & 0xFFFF, raw))
+        return raw
+
+    def read_raw_pressure(self):
+        """Reads the raw (uncompensated) pressure level from the sensor."""
+        self._device.write8(BMP085_CONTROL, BMP085_READPRESSURECMD + (self._mode << 6))
+        if self._mode == BMP085_ULTRALOWPOWER:
+            time.sleep(0.005)
+        elif self._mode == BMP085_HIGHRES:
+            time.sleep(0.014)
+        elif self._mode == BMP085_ULTRAHIGHRES:
+            time.sleep(0.026)
+        else:
+            time.sleep(0.008)
+        msb = self._device.readU8(BMP085_PRESSUREDATA)
+        lsb = self._device.readU8(BMP085_PRESSUREDATA+1)
+        xlsb = self._device.readU8(BMP085_PRESSUREDATA+2)
+        raw = ((msb << 16) + (lsb << 8) + xlsb) >> (8 - self._mode)
+        self._logger.debug('Raw pressure 0x{0:04X} ({1})'.format(raw & 0xFFFF, raw))
+        return raw
+
+    def read_temperature(self):
+        """Gets the compensated temperature in degrees celsius."""
+        UT = self.read_raw_temp()
+        # Datasheet value for debugging:
+        #UT = 27898
+        # Calculations below are taken straight from section 3.5 of the datasheet.
+        X1 = ((UT - self.cal_AC6) * self.cal_AC5) >> 15
+        X2 = (self.cal_MC << 11) // (X1 + self.cal_MD)
+        B5 = X1 + X2
+        temp = ((B5 + 8) >> 4) / 10.0
+        self._logger.debug('Calibrated temperature {0} C'.format(temp))
+        return temp
+
+    def read_pressure(self):
+        """Gets the compensated pressure in Pascals."""
+        UT = self.read_raw_temp()
+        UP = self.read_raw_pressure()
+        # Datasheet values for debugging:
+        #UT = 27898
+        #UP = 23843
+        # Calculations below are taken straight from section 3.5 of the datasheet.
+        # Calculate true temperature coefficient B5.
+        X1 = ((UT - self.cal_AC6) * self.cal_AC5) >> 15
+        X2 = (self.cal_MC << 11) // (X1 + self.cal_MD)
+        B5 = X1 + X2
+        self._logger.debug('B5 = {0}'.format(B5))
+        # Pressure Calculations
+        B6 = B5 - 4000
+        self._logger.debug('B6 = {0}'.format(B6))
+        X1 = (self.cal_B2 * (B6 * B6) >> 12) >> 11
+        X2 = (self.cal_AC2 * B6) >> 11
+        X3 = X1 + X2
+        B3 = (((self.cal_AC1 * 4 + X3) << self._mode) + 2) // 4
+        self._logger.debug('B3 = {0}'.format(B3))
+        X1 = (self.cal_AC3 * B6) >> 13
+        X2 = (self.cal_B1 * ((B6 * B6) >> 12)) >> 16
+        X3 = ((X1 + X2) + 2) >> 2
+        B4 = (self.cal_AC4 * (X3 + 32768)) >> 15
+        self._logger.debug('B4 = {0}'.format(B4))
+        B7 = (UP - B3) * (50000 >> self._mode)
+        self._logger.debug('B7 = {0}'.format(B7))
+        if B7 < 0x80000000:
+            p = (B7 * 2) // B4
+        else:
+            p = (B7 // B4) * 2
+        X1 = (p >> 8) * (p >> 8)
+        X1 = (X1 * 3038) >> 16
+        X2 = (-7357 * p) >> 16
+        p = p + ((X1 + X2 + 3791) >> 4)
+        self._logger.debug('Pressure {0} Pa'.format(p))
+        return p
+
+    def read_altitude(self, sealevel_pa=101325.0):
+        """Calculates the altitude in meters."""
+        # Calculation taken straight from section 3.6 of the datasheet.
+        pressure = float(self.read_pressure())
+        altitude = 44330.0 * (1.0 - pow(pressure / sealevel_pa, (1.0/5.255)))
+        self._logger.debug('Altitude {0} m'.format(altitude))
+        return altitude
+
+    def read_sealevel_pressure(self, altitude_m=0.0):
+        """Calculates the pressure at sealevel when given a known altitude in
+        meters. Returns a value in Pascals."""
+        pressure = float(self.read_pressure())
+        p0 = pressure / pow(1.0 - altitude_m/44330.0, 5.255)
+        self._logger.debug('Sealevel pressure {0} Pa'.format(p0))
+        return p0

--- a/robophery/i2c/bmp085.py
+++ b/robophery/i2c/bmp085.py
@@ -23,7 +23,7 @@
 from __future__ import division
 import logging
 import time
-from robophery.i2c import I2cModule
+from robophery.i2c import (I2cModule, I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
 
 # BMP085 default address.
 BMP085_I2CADDR           = 0x77
@@ -67,14 +67,7 @@ class BMP085Module(I2cModule):
             raise ValueError('Unexpected i2c_interface value {0}.  Set I2C interface to one of I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE'.format(mode))
         self._i2c_interface = kwargs.get('i2c_interface')
 
-#TODO This logic should be in init. Left for initil testing as it is.
-        # Create I2C device.
-        if self._i2c_interface is I2C_ADAFRUIT_I2C_INTERFACE:
-            import Adafruit_GPIO.I2C as I2C
-            i2c = I2C
-            self.bus = i2c.get_i2c_device(address, **kwargs)
-        elif (self._i2c_interface is I2C_SMBUS_INTERFACE):
-            self.set_bus(kwargs.get('bus'))
+        self.set_bus(kwargs.get('bus'), BMP085_I2CADDR, self._i2c_interface)
 
         self._logger = logging.getLogger('Adafruit_BMP.BMP085')
 

--- a/robophery/i2c/bmp085.py
+++ b/robophery/i2c/bmp085.py
@@ -25,6 +25,7 @@ import logging
 import time
 from robophery.i2c import (I2cModule, I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
 
+BMP085_NAME_DEFAULT      = 'BMP085 sensor'
 # BMP085 default address.
 BMP085_I2CADDR           = 0x77
 
@@ -57,17 +58,18 @@ BMP085_READPRESSURECMD   = 0x34
 class BMP085Module(I2cModule):
 
     def __init__(self, kwargs):
-        self.name = kwargs.get('name')
-
+        if kwargs.get('name') is '':
+            self.name = BMP085_NAME_DEFAULT
+        else:
+            self.name = kwargs.get('name')
         if kwargs.get('mode') not in [BMP085_ULTRALOWPOWER, BMP085_STANDARD, BMP085_HIGHRES, BMP085_ULTRAHIGHRES]:
             raise ValueError('Unexpected mode value {0}.  Set mode to one of BMP085_ULTRALOWPOWER, BMP085_STANDARD, BMP085_HIGHRES, or BMP085_ULTRAHIGHRES'.format(mode))
         self._mode = kwargs.get('mode')
+        #TODO make this as kwarg
+        self.set_addr(kwargs.get('address'))
+        self.set_bus(kwargs.get('bus'), I2C_ADAFRUIT_I2C_INTERFACE)
 
-        if kwargs.get('i2c_interface') not in [I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE]:
-            raise ValueError('Unexpected i2c_interface value {0}.  Set I2C interface to one of I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE'.format(mode))
-        self._i2c_interface = kwargs.get('i2c_interface')
-
-        self.set_bus(kwargs.get('bus'), BMP085_I2CADDR, self._i2c_interface)
+        self._device = i2c.get_i2c_device(self.addr, **kwargs)
 
         self._logger = logging.getLogger('Adafruit_BMP.BMP085')
 
@@ -75,17 +77,17 @@ class BMP085Module(I2cModule):
         self._load_calibration()
 
     def _load_calibration(self):
-        self.cal_AC1 = self.bus.readS16BE(BMP085_CAL_AC1)   # INT16
-        self.cal_AC2 = self.bus.readS16BE(BMP085_CAL_AC2)   # INT16
-        self.cal_AC3 = self.bus.readS16BE(BMP085_CAL_AC3)   # INT16
-        self.cal_AC4 = self.bus.readU16BE(BMP085_CAL_AC4)   # UINT16
-        self.cal_AC5 = self.bus.readU16BE(BMP085_CAL_AC5)   # UINT16
-        self.cal_AC6 = self.bus.readU16BE(BMP085_CAL_AC6)   # UINT16
-        self.cal_B1 = self.bus.readS16BE(BMP085_CAL_B1)     # INT16
-        self.cal_B2 = self.bus.readS16BE(BMP085_CAL_B2)     # INT16
-        self.cal_MB = self.bus.readS16BE(BMP085_CAL_MB)     # INT16
-        self.cal_MC = self.bus.readS16BE(BMP085_CAL_MC)     # INT16
-        self.cal_MD = self.bus.readS16BE(BMP085_CAL_MD)     # INT16
+        self.cal_AC1 = self._device.readS16BE(BMP085_CAL_AC1)   # INT16
+        self.cal_AC2 = self._device.readS16BE(BMP085_CAL_AC2)   # INT16
+        self.cal_AC3 = self._device.readS16BE(BMP085_CAL_AC3)   # INT16
+        self.cal_AC4 = self._device.readU16BE(BMP085_CAL_AC4)   # UINT16
+        self.cal_AC5 = self._device.readU16BE(BMP085_CAL_AC5)   # UINT16
+        self.cal_AC6 = self._device.readU16BE(BMP085_CAL_AC6)   # UINT16
+        self.cal_B1 = self._device.readS16BE(BMP085_CAL_B1)     # INT16
+        self.cal_B2 = self._device.readS16BE(BMP085_CAL_B2)     # INT16
+        self.cal_MB = self._device.readS16BE(BMP085_CAL_MB)     # INT16
+        self.cal_MC = self._device.readS16BE(BMP085_CAL_MC)     # INT16
+        self.cal_MD = self._device.readS16BE(BMP085_CAL_MD)     # INT16
         self._logger.debug('AC1 = {0:6d}'.format(self.cal_AC1))
         self._logger.debug('AC2 = {0:6d}'.format(self.cal_AC2))
         self._logger.debug('AC3 = {0:6d}'.format(self.cal_AC3))
@@ -115,15 +117,15 @@ class BMP085Module(I2cModule):
 
     def read_raw_temp(self):
         """Reads the raw (uncompensated) temperature from the sensor."""
-        self.bus.write8(BMP085_CONTROL, BMP085_READTEMPCMD)
+        self._device.write8(BMP085_CONTROL, BMP085_READTEMPCMD)
         time.sleep(0.005)  # Wait 5ms
-        raw = self.bus.readU16BE(BMP085_TEMPDATA)
+        raw = self._device.readU16BE(BMP085_TEMPDATA)
         self._logger.debug('Raw temp 0x{0:X} ({1})'.format(raw & 0xFFFF, raw))
         return raw
 
     def read_raw_pressure(self):
         """Reads the raw (uncompensated) pressure level from the sensor."""
-        self.bus.write8(BMP085_CONTROL, BMP085_READPRESSURECMD + (self._mode << 6))
+        self._device.write8(BMP085_CONTROL, BMP085_READPRESSURECMD + (self._mode << 6))
         if self._mode == BMP085_ULTRALOWPOWER:
             time.sleep(0.005)
         elif self._mode == BMP085_HIGHRES:
@@ -132,9 +134,9 @@ class BMP085Module(I2cModule):
             time.sleep(0.026)
         else:
             time.sleep(0.008)
-        msb = self.bus.readU8(BMP085_PRESSUREDATA)
-        lsb = self.bus.readU8(BMP085_PRESSUREDATA+1)
-        xlsb = self.bus.readU8(BMP085_PRESSUREDATA+2)
+        msb = self._device.readU8(BMP085_PRESSUREDATA)
+        lsb = self._device.readU8(BMP085_PRESSUREDATA+1)
+        xlsb = self._device.readU8(BMP085_PRESSUREDATA+2)
         raw = ((msb << 16) + (lsb << 8) + xlsb) >> (8 - self._mode)
         self._logger.debug('Raw pressure 0x{0:04X} ({1})'.format(raw & 0xFFFF, raw))
         return raw

--- a/tests/i2c/bmp085_tests.py
+++ b/tests/i2c/bmp085_tests.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Can enable debug output by uncommenting:
+#import logging
+#logging.basicConfig(level=logging.DEBUG)
+
+#import Adafruit_BMP.BMP085 as BMP085
+import sys
+import time
+#sys.path.append('/root/sdcard/git/robophery-dev/')
+sys.path.append('/home/mato/work/git/robophery-dev/')
+
+#from robophery.i2c.bmp085 import BMP085Module
+import robophery.i2c.bmp085 as bmp085
+from robophery.i2c import (I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
+
+# Default constructor will pick a default I2C bus.
+#
+# For the Raspberry Pi this means you should hook up to the only exposed I2C bus
+# from the main GPIO header and the library will figure out the bus number based
+# on the Pi's revision.
+#
+# For the Beaglebone Black the library will assume bus 1 by default, which is
+# exposed with SCL = P9_19 and SDA = P9_20.
+
+# Optionally you can override the bus number:
+#sensor = BMP085.BMP085(busnum=2)
+
+# You can also optionally change the BMP085 mode to one of BMP085_ULTRALOWPOWER,
+# BMP085_STANDARD, BMP085_HIGHRES, or BMP085_ULTRAHIGHRES.  See the BMP085
+# datasheet for more details on the meanings of each mode (accuracy and power
+# consumption are primarily the differences).  The default mode is STANDARD.
+#sensor = BMP085.BMP085(mode=BMP085.BMP085_ULTRAHIGHRES)
+
+def main():
+    cfg = {'name': 'BMP180', 'bus': 2, 'mode': bmp085.BMP085_ULTRAHIGHRES, 'i2c_interface': I2C_ADAFRUIT_I2C_INTERFACE}
+    
+    bmp180sensor = bmp085.BMP085Module(cfg)
+
+    while True:
+        print('Temp = {0:0.2f} *C'.format(bmp180sensor.read_temperature()))
+        print('Pressure = {0:0.2f} Pa'.format(bmp180sensor.read_pressure()))
+        print('Altitude = {0:0.2f} m'.format(bmp180sensor.read_altitude()))
+        print('Sealevel Pressure = {0:0.2f} Pa'.format(bmp180sensor.read_sealevel_pressure()))
+
+if __name__=="__main__":
+    main()

--- a/tests/i2c/bmp085_tests.py
+++ b/tests/i2c/bmp085_tests.py
@@ -27,12 +27,13 @@
 #import Adafruit_BMP.BMP085 as BMP085
 import sys
 import time
-#sys.path.append('/root/sdcard/git/robophery-dev/')
-sys.path.append('/home/mato/work/git/robophery-dev/')
+sys.path.append('/root/sdcard/git/robophery-dev/')
+#sys.path.append('/home/mato/work/git/robophery-dev/')
 
 #from robophery.i2c.bmp085 import BMP085Module
 import robophery.i2c.bmp085 as bmp085
 from robophery.i2c import (I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
+#from robophery.i2c import I2cModule
 
 # Default constructor will pick a default I2C bus.
 #
@@ -53,7 +54,12 @@ from robophery.i2c import (I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
 #sensor = BMP085.BMP085(mode=BMP085.BMP085_ULTRAHIGHRES)
 
 def main():
-    cfg = {'name': 'BMP180', 'bus': 2, 'mode': bmp085.BMP085_ULTRAHIGHRES, 'i2c_interface': I2C_ADAFRUIT_I2C_INTERFACE}
+    cfg =   { 
+                'name': 'BMP180', 
+                'bus': 2, 
+                'mode': bmp085.BMP085_ULTRAHIGHRES, 
+                'i2c_interface': I2C_ADAFRUIT_I2C_INTERFACE
+            }
     
     bmp180sensor = bmp085.BMP085Module(cfg)
 
@@ -62,6 +68,7 @@ def main():
         print('Pressure = {0:0.2f} Pa'.format(bmp180sensor.read_pressure()))
         print('Altitude = {0:0.2f} m'.format(bmp180sensor.read_altitude()))
         print('Sealevel Pressure = {0:0.2f} Pa'.format(bmp180sensor.read_sealevel_pressure()))
+        time.sleep(1)
 
 if __name__=="__main__":
     main()

--- a/tests/i2c/bmp085_tests.py
+++ b/tests/i2c/bmp085_tests.py
@@ -28,37 +28,16 @@
 import sys
 import time
 sys.path.append('/root/sdcard/git/robophery-dev/')
-#sys.path.append('/home/mato/work/git/robophery-dev/')
 
-#from robophery.i2c.bmp085 import BMP085Module
 import robophery.i2c.bmp085 as bmp085
 from robophery.i2c import (I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
-#from robophery.i2c import I2cModule
-
-# Default constructor will pick a default I2C bus.
-#
-# For the Raspberry Pi this means you should hook up to the only exposed I2C bus
-# from the main GPIO header and the library will figure out the bus number based
-# on the Pi's revision.
-#
-# For the Beaglebone Black the library will assume bus 1 by default, which is
-# exposed with SCL = P9_19 and SDA = P9_20.
-
-# Optionally you can override the bus number:
-#sensor = BMP085.BMP085(busnum=2)
-
-# You can also optionally change the BMP085 mode to one of BMP085_ULTRALOWPOWER,
-# BMP085_STANDARD, BMP085_HIGHRES, or BMP085_ULTRAHIGHRES.  See the BMP085
-# datasheet for more details on the meanings of each mode (accuracy and power
-# consumption are primarily the differences).  The default mode is STANDARD.
-#sensor = BMP085.BMP085(mode=BMP085.BMP085_ULTRAHIGHRES)
 
 def main():
     cfg =   { 
                 'name': 'BMP180', 
+                'address': bmp085.BMP085_I2CADDR
                 'bus': 2, 
                 'mode': bmp085.BMP085_ULTRAHIGHRES, 
-                'i2c_interface': I2C_ADAFRUIT_I2C_INTERFACE
             }
     
     bmp180sensor = bmp085.BMP085Module(cfg)

--- a/tests/i2c/bmp085_tests.py
+++ b/tests/i2c/bmp085_tests.py
@@ -30,14 +30,13 @@ import time
 sys.path.append('/root/sdcard/git/robophery-dev/')
 
 import robophery.i2c.bmp085 as bmp085
-from robophery.i2c import (I2C_SMBUS_INTERFACE, I2C_ADAFRUIT_I2C_INTERFACE)
 
 def main():
     cfg =   { 
                 'name': 'BMP180', 
-                'address': bmp085.BMP085_I2CADDR
-                'bus': 2, 
-                'mode': bmp085.BMP085_ULTRAHIGHRES, 
+                'address': bmp085.BMP085_I2CADDR,
+                'busnum': 2,
+                'mode': bmp085.BMP085_ULTRAHIGHRES
             }
     
     bmp180sensor = bmp085.BMP085Module(cfg)


### PR DESCRIPTION
Je to sice funkcne ale nehovorim ze konecna verzia skor aby sme sa mali o com bavit.

Opustil som od definovania jednotlivych typov interfacov ako parameter do nejakej funkcie napr set_bus(). Problem je ze v nasom set_bus() sa dava do parametru "bus" interface na dane zariadenie na SMBusu. S tym sa dalej pracuje v drivery od BH1750. U Adafruitu to maju ale este zabalene v dalsom objekte "Device" ktory ma vo svojom konstruktore volanie ich vlastneho SMBusu (alebo nejakeho ineho podobneho interfacu). V samotnom drivery sa potom ale volaju metody toho "Devicu" ktore niesu stejne ako SMBusu.

Preto som momentalne pridal set_device() s tym ze driver ktory je napisany pre Adafruit_I2C ho proste vola a pouziva "device" parameter na zapis na zbernicu a ten ktory pouziva SMBus vola set_bus a pouziva "bus" parameter.

Ak by si sa chcel pozret o com hovorim tak tu je ten [Adafruiti I2C](https://github.com/adafruit/Adafruit_Python_GPIO/blob/master/Adafruit_GPIO/I2C.py)